### PR TITLE
chore: enable feeds

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -47,7 +47,7 @@ date_format = "%Y-%m-%d"
 navigation = [
   { url = "$BASE_URL/archive", title = "Archive" },
   { url = "$BASE_URL/tags", title = "Tags" },
-  { url = "https://getzola.com/", title = "Zola", is_external = true }
+  { url = "https://getzola.org/", title = "Zola", is_external = true }
 ]
 
 home_title = "The Trait Modern"

--- a/config.toml
+++ b/config.toml
@@ -7,6 +7,9 @@ compile_sass = true
 # Whether to build a search index to be used later on by a JavaScript library
 build_search_index = false
 
+# Generate an atom/rss feed
+generate_feed = true
+
 theme = "papermod"
 
 taxonomies = [


### PR DESCRIPTION
Makes it easy to import into RSS readers. Also fixed the zola link, it uses .org not .com